### PR TITLE
add CGINCLUDE to grammars

### DIFF
--- a/grammars/shaderlab.cson
+++ b/grammars/shaderlab.cson
@@ -13,7 +13,7 @@
 		'name': 'support.class.shaderlab'
 	}
 	{ # Cg shader section
-		'match': '\\b(CGPROGRAM|ENDCG)\\b'
+		'match': '\\b(CGPROGRAM|CGINCLUDE|ENDCG)\\b'
 		'name': 'support.class.shaderlab'
 	}
 	{ # Dependency and fallback


### PR DESCRIPTION
Forgot to issue this PR, adding `CGINCLUDE` to grammars (example usage of `CGINCLUDE` [here](http://makegamessa.com/discussion/1987/intro-to-unity-shaders))